### PR TITLE
Update to work with 0.90.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     </parent>
 
     <properties>
-        <elasticsearch.version>0.90.0.Beta1</elasticsearch.version>
+        <elasticsearch.version>0.90.0</elasticsearch.version>
     </properties>
 
     <repositories>

--- a/src/main/java/org/elasticsearch/memcached/common/Bytes.java
+++ b/src/main/java/org/elasticsearch/memcached/common/Bytes.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.memcached.common;
+
+/**
+ *
+ */
+public class Bytes {
+
+    final static int[] sizeTable = {9, 99, 999, 9999, 99999, 999999, 9999999, 99999999, 999999999, Integer.MAX_VALUE};
+
+    static int stringSize(int x) {
+        for (int i = 0; ; i++)
+            if (x <= sizeTable[i])
+                return i + 1;
+    }
+
+    /**
+     * Blatant copy of Integer.toString, but returning a byte array instead of a String, as
+     * string charset decoding/encoding was killing us on performance.
+     *
+     * @param i integer to convert
+     * @return byte[] array containing literal ASCII char representation
+     */
+    public static byte[] itoa(int i) {
+        int size = (i < 0) ? stringSize(-i) + 1 : stringSize(i);
+        byte[] buf = new byte[size];
+        getChars(i, size, buf);
+        return buf;
+    }
+
+    final static byte[] digits = {
+            '0', '1', '2', '3', '4', '5',
+            '6', '7', '8', '9', 'a', 'b',
+            'c', 'd', 'e', 'f', 'g', 'h',
+            'i', 'j', 'k', 'l', 'm', 'n',
+            'o', 'p', 'q', 'r', 's', 't',
+            'u', 'v', 'w', 'x', 'y', 'z'
+    };
+
+    final static byte[] DigitTens = {
+            '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
+            '1', '1', '1', '1', '1', '1', '1', '1', '1', '1',
+            '2', '2', '2', '2', '2', '2', '2', '2', '2', '2',
+            '3', '3', '3', '3', '3', '3', '3', '3', '3', '3',
+            '4', '4', '4', '4', '4', '4', '4', '4', '4', '4',
+            '5', '5', '5', '5', '5', '5', '5', '5', '5', '5',
+            '6', '6', '6', '6', '6', '6', '6', '6', '6', '6',
+            '7', '7', '7', '7', '7', '7', '7', '7', '7', '7',
+            '8', '8', '8', '8', '8', '8', '8', '8', '8', '8',
+            '9', '9', '9', '9', '9', '9', '9', '9', '9', '9',
+    };
+
+    final static byte[] DigitOnes = {
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    };
+
+    static void getChars(int i, int index, byte[] buf) {
+        int q, r;
+        int charPos = index;
+        byte sign = 0;
+
+        if (i < 0) {
+            sign = '-';
+            i = -i;
+        }
+
+        // Generate two digits per iteration
+        while (i >= 65536) {
+            q = i / 100;
+            // really: r = i - (q * 100);
+            r = i - ((q << 6) + (q << 5) + (q << 2));
+            i = q;
+            buf[--charPos] = DigitOnes[r];
+            buf[--charPos] = DigitTens[r];
+        }
+
+        // Fall thru to fast mode for smaller numbers
+        // assert(i <= 65536, i);
+        for (; ; ) {
+            q = (i * 52429) >>> (16 + 3);
+            r = i - ((q << 3) + (q << 1));  // r = i-(q*10) ...
+            buf[--charPos] = digits[r];
+            i = q;
+            if (i == 0) break;
+        }
+        if (sign != 0) {
+            buf[--charPos] = sign;
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/memcached/netty/MemcachedRestChannel.java
+++ b/src/main/java/org/elasticsearch/memcached/netty/MemcachedRestChannel.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.memcached.netty;
 
-import org.elasticsearch.common.Bytes;
 import org.elasticsearch.common.Unicode;
 import org.elasticsearch.common.io.stream.CachedStreamOutput;
 import org.elasticsearch.common.netty.buffer.ChannelBuffer;
@@ -28,6 +27,7 @@ import org.elasticsearch.common.netty.channel.Channel;
 import org.elasticsearch.common.netty.channel.ChannelFuture;
 import org.elasticsearch.common.netty.channel.ChannelFutureListener;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.memcached.common.Bytes;
 import org.elasticsearch.memcached.MemcachedRestRequest;
 import org.elasticsearch.memcached.MemcachedTransportException;
 import org.elasticsearch.rest.RestChannel;


### PR DESCRIPTION
The current plugin version does not work with 0.90.0 because of missing classes. In addition the exception is swallowed in the MemcachedRestChannel class.
- Bumped the version
- The org.elasticsearch.common.Bytes class was removed from 0.90.0RC2 to 0.90.0, thus leading to compilation failure
- The Bytes class has been simply copied into org.elasticsearch.memcached.common in order to avoid conflicts
